### PR TITLE
generate-tokens added

### DIFF
--- a/src/hope_dedup_engine/apps/api/admin/config.py
+++ b/src/hope_dedup_engine/apps/api/admin/config.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+from uuid import uuid4
 
 from django.contrib import messages
 from django.contrib.admin import ModelAdmin, register
@@ -123,3 +124,8 @@ class ConfigAdmin(ExtraButtonsMixin, ModelAdmin):
     #             **context,
     #         },
     #     )
+
+    def save_model(self, request, obj, form, change):
+        if not obj.root_token:  
+            obj.root_token = uuid4().hex  # Generate token if not provided
+        super().save_model(request, obj, form, change)

--- a/src/hope_dedup_engine/apps/api/admin/finding.py
+++ b/src/hope_dedup_engine/apps/api/admin/finding.py
@@ -1,10 +1,12 @@
 from django.contrib.admin import ModelAdmin, register
+from uuid import uuid4
+from django.contrib import admin
 
 from adminfilters.autocomplete import AutoCompleteFilter
 from adminfilters.filters import DjangoLookupFilter, NumberFilter
 from adminfilters.mixin import AdminFiltersMixin
 
-from hope_dedup_engine.apps.api.models import Finding, Image
+from hope_dedup_engine.apps.api.models import Finding, Image, Config
 
 from .base import DeduplicationSetLightQuerysetMixin
 
@@ -41,3 +43,15 @@ class FindingAdmin(AdminFiltersMixin, DeduplicationSetLightQuerysetMixin, ModelA
 
     def has_delete_permission(self, request, obj=None):
         return obj is not None
+
+
+@admin.register(Config)
+class ConfigAdmin(admin.ModelAdmin):
+    list_display = ("name", "settings", "created_at")
+    fields = ("name", "settings", "root_token")
+    readonly_fields = ("created_at",)
+
+    def save_model(self, request, obj, form, change):
+        if not obj.root_token:
+            obj.root_token = uuid4().hex  
+        super().save_model(request, obj, form, change)

--- a/src/hope_dedup_engine/apps/api/models/auth.py
+++ b/src/hope_dedup_engine/apps/api/models/auth.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db import models
-
 from rest_framework.authtoken.models import Token
+import secrets
 
 
 class HDEToken(Token):
@@ -10,3 +10,8 @@ class HDEToken(Token):
     """
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="auth_tokens", on_delete=models.CASCADE)
+
+    def save(self, *args, **kwargs):
+        if not self.key:
+            self.key = secrets.token_hex(20)  # Generate a 40-character token
+        super().save(*args, **kwargs)


### PR DESCRIPTION
# PR: Add Token Generation
closes #131
## Description  
This PR introduces token generation . If an object does not already have a `root_token`, one will be automatically generated using `uuid4().hex`. This ensures that each object has a unique identifier when being saved.  

## Changes Made  
- Modified `save_model` method to check if `root_token` is missing.  
- If `root_token` is not provided, it is now generated using `uuid4().hex`.   