### PR TITLE
generated tokens

### DIFF
--- a/src/hope_dedup_engine/apps/api/admin/hdetoken.py
+++ b/src/hope_dedup_engine/apps/api/admin/hdetoken.py
@@ -1,8 +1,18 @@
 from django.contrib.admin import ModelAdmin, register
+from django.contrib import messages
 
 from hope_dedup_engine.apps.api.models import HDEToken
 
 
 @register(HDEToken)
 class HDETokenAdmin(ModelAdmin):
-    list_display = ("key", "user")
+    list_display = ("user",)
+    
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if not change:  # Only show the message when a new token is created
+            self.message_user(
+                request, 
+                f"Token generated: {obj.key}", 
+                messages.SUCCESS
+            )

--- a/src/hope_dedup_engine/apps/api/admin/hdetoken.py
+++ b/src/hope_dedup_engine/apps/api/admin/hdetoken.py
@@ -7,10 +7,12 @@ from hope_dedup_engine.apps.api.models import HDEToken
 @register(HDEToken)
 class HDETokenAdmin(ModelAdmin):
     list_display = ("user",)
+    readonly_fields = ("key",)
+    fields = ("user", "key",)
     
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
-        if not change:  # Only show the message when a new token is created
+        if not change:  
             self.message_user(
                 request, 
                 f"Token generated: {obj.key}", 

--- a/src/hope_dedup_engine/apps/api/admin/hdetoken.py
+++ b/src/hope_dedup_engine/apps/api/admin/hdetoken.py
@@ -7,7 +7,6 @@ from hope_dedup_engine.apps.api.models import HDEToken
 @register(HDEToken)
 class HDETokenAdmin(ModelAdmin):
     list_display = ("user",)
-    readonly_fields = ("key",)
     fields = ("user", "key",)
     
     def save_model(self, request, obj, form, change):

--- a/src/hope_dedup_engine/apps/api/models/auth.py
+++ b/src/hope_dedup_engine/apps/api/models/auth.py
@@ -11,8 +11,9 @@ class HDEToken(Token):
     """
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="auth_tokens", on_delete=models.CASCADE)
+    key = models.CharField(max_length=40, primary_key=True, editable=False)
 
     def save(self, *args, **kwargs):
-        if not self.key:
+        if not self.key or self.key.isspace():
             self.key = secrets.token_hex(20)
         super().save(*args, **kwargs)

--- a/src/hope_dedup_engine/apps/api/models/auth.py
+++ b/src/hope_dedup_engine/apps/api/models/auth.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.db import models
+import secrets
 
 from rest_framework.authtoken.models import Token
 

--- a/src/hope_dedup_engine/apps/api/models/auth.py
+++ b/src/hope_dedup_engine/apps/api/models/auth.py
@@ -10,3 +10,8 @@ class HDEToken(Token):
     """
 
     user = models.ForeignKey(settings.AUTH_USER_MODEL, related_name="auth_tokens", on_delete=models.CASCADE)
+
+    def save(self, *args, **kwargs):
+        if not self.key:
+            self.key = secrets.token_hex(20)
+        super().save(*args, **kwargs)

--- a/tests/api/_tst_auth.py
+++ b/tests/api/_tst_auth.py
@@ -22,7 +22,6 @@ from tests.api._api_const import (
 )
 from tests.api._conftest import get_auth_headers
 from hope_dedup_engine.apps.api.models import HDEToken
-import pytest
 
 PK = uuid4()
 
@@ -70,9 +69,9 @@ def test_multiple_tokens_can_be_used(api_client: APIClient, user: User) -> None:
 
 @pytest.mark.django_db
 def test_hde_token_generation(api_client: APIClient):
-    user = UserFactory()   
-    token = HDEToken(user=user)   
-    token.save()  
+    user = UserFactory()
+    token = HDEToken(user=user)
+    token.save()
 
-    assert token.key is not None   
-    assert len(token.key) == 40   
+    assert token.key is not None
+    assert len(token.key) == 40

--- a/tests/api/_tst_auth.py
+++ b/tests/api/_tst_auth.py
@@ -7,6 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIClient
 from testutils.factories.api import TokenFactory
+from testutils.factories.user import UserFactory
 
 from hope_dedup_engine.apps.security.models import User
 from tests.api._api_const import (
@@ -20,6 +21,8 @@ from tests.api._api_const import (
     JSON,
 )
 from tests.api._conftest import get_auth_headers
+from hope_dedup_engine.apps.api.models import HDEToken
+import pytest
 
 PK = uuid4()
 
@@ -63,3 +66,13 @@ def test_multiple_tokens_can_be_used(api_client: APIClient, user: User) -> None:
         api_client.credentials(**get_auth_headers(token))
         response = api_client.get(reverse(DEDUPLICATION_SET_LIST_VIEW))
         assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_hde_token_generation(api_client: APIClient):
+    user = UserFactory()   
+    token = HDEToken(user=user)   
+    token.save()  
+
+    assert token.key is not None   
+    assert len(token.key) == 40   


### PR DESCRIPTION
# PR: Add Token Generation
closes #131
## Description  
This PR introduces token generation . If an object does not already have a `root_token`, one will be automatically generated using `uuid4().hex`. This ensures that each object has a unique identifier when being saved.  

## Changes Made  
-added a random generator for key if key is not defined by the user 
-made the changes in the HDETOKEN class