### PR TITLE
Close connections initialized_only

### DIFF
--- a/src/hope_dedup_engine/config/celery.py
+++ b/src/hope_dedup_engine/config/celery.py
@@ -23,8 +23,14 @@ def init_sentry(**_kwargs: Any) -> None:
 def reset_db_connection_pool(**_kwargs: Any) -> None:
     from django.db import connections  # noqa: PLC0415
 
-    for connection in connections.all():
-        connection.close()
+    connections.close_all()
+
+
+@signals.task_postrun.connect
+def on_task_postrun(**_kwargs: Any) -> None:
+    from django.db import connections  # noqa: PLC0415
+
+    connections.close_all()
 
 
 class DedupeTask(Task):

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,5 +1,11 @@
-from hope_dedup_engine.config.celery import app
-from hope_dedup_engine.config.celery import init_sentry
+from pytest_mock import MockerFixture
+
+from hope_dedup_engine.config.celery import (
+    app,
+    init_sentry,
+    on_task_postrun,
+    reset_db_connection_pool,
+)
 
 
 def test_celery():
@@ -8,3 +14,15 @@ def test_celery():
 
 def test_init_celery():
     init_sentry()
+
+
+def test_reset_db_connection_pool(mocker: MockerFixture) -> None:
+    mock_connections = mocker.patch("django.db.connections")
+    reset_db_connection_pool()
+    mock_connections.close_all.assert_called_once()
+
+
+def test_on_task_postrun(mocker: MockerFixture) -> None:
+    mock_connections = mocker.patch("django.db.connections")
+    on_task_postrun()
+    mock_connections.close_all.assert_called_once()


### PR DESCRIPTION
We can close the connections [gracefully](https://github.com/django/django/blob/6c37a2fbb2c4a132362728b309f1eb1ef9113cb7/django/utils/connection.py#L83) and not close all the lazily loaded ones.