### PR TITLE
add face coverage threshold to DeepFace encoding pipeline

### DIFF
--- a/src/hope_dedup_engine/apps/api/deduplication/config.py
+++ b/src/hope_dedup_engine/apps/api/deduplication/config.py
@@ -42,6 +42,7 @@ class DeduplicationSetConfig:
     duplicate_confidence_threshold: float = field(
         default_factory=lambda: constance_cfg.DEFAULT_DUPLICATE_CONFIDENCE_THRESHOLD * 100
     )  # Normalized to 0..100 range
+    face_coverage_threshold: float = field(default_factory=lambda: constance_cfg.DEFAULT_FACE_COVERAGE_THRESHOLD)
 
     def update(self, overrides: dict[str, Any]) -> None:
         if not isinstance(overrides, dict):

--- a/src/hope_dedup_engine/apps/api/models/deduplication.py
+++ b/src/hope_dedup_engine/apps/api/models/deduplication.py
@@ -134,6 +134,7 @@ class Encoding(models.Model):
         FILE_NOT_FOUND = 404, "no file found"
         NO_FACE_DETECTED = 412, "no face detected"
         FACE_NOT_ACCEPTED = 416, "face was detected but did not meet confidence threshold"
+        INSUFFICIENT_FACE_COVERAGE = 417, "face does not cover sufficient part of the image"
         MULTIPLE_FACES_DETECTED = 429, "multiple faces detected"
         GENERIC_ERROR = 500, "generic error"
 
@@ -184,6 +185,7 @@ class EncodingErrorGroup:
     FACE_DETECT = (
         Encoding.StatusCode.FACE_NOT_ACCEPTED,
         Encoding.StatusCode.NO_FACE_DETECTED,
+        Encoding.StatusCode.INSUFFICIENT_FACE_COVERAGE,
         Encoding.StatusCode.MULTIPLE_FACES_DETECTED,
     )
     SYSTEM = (Encoding.StatusCode.FILE_NOT_FOUND, Encoding.StatusCode.GENERIC_ERROR)

--- a/src/hope_dedup_engine/apps/faces/celery_tasks.py
+++ b/src/hope_dedup_engine/apps/faces/celery_tasks.py
@@ -77,6 +77,7 @@ def encode_chunk(
             deduplication_set,
             encoding_ids,
             config.face_confidence_threshold,
+            config.face_coverage_threshold,
             config.deduplicate.model_name,
             config.deduplicate.detector_backend,
             align=config.deduplicate.align,

--- a/src/hope_dedup_engine/apps/faces/services/facial.py
+++ b/src/hope_dedup_engine/apps/faces/services/facial.py
@@ -1,6 +1,6 @@
 import logging
 from uuid import UUID
-
+from typing import Any, Mapping
 from azure.core.exceptions import ResourceNotFoundError
 from deepface import DeepFace
 from django.db import transaction
@@ -15,8 +15,20 @@ logger = logging.getLogger(__name__)
 Embedding = list[float]
 
 
-def encode_face(
-    data: ndarray, face_confidence_threshold: float, model_name: str, detector_backend: str, align: bool
+def is_face_coverage(coverage_threshold: float, fa: Mapping[str, Any]) -> bool:
+    """Return True if face bbox area is at least `coverage_threshold` of the source image."""
+    fa_box = fa["w"] * fa["h"]
+    img_box = fa["img_w"] * fa["img_h"]
+    return 0.0 <= coverage_threshold <= 1.0 and (fa_box / img_box) >= coverage_threshold
+
+
+def encode_face(  # noqa: PLR0911, PLR0913
+    data: ndarray,
+    face_confidence_threshold: float,
+    face_coverage_threshold: float,
+    model_name: str,
+    detector_backend: str,
+    align: bool,
 ) -> tuple[Embedding, Encoding.StatusCode | None] | tuple[None, Encoding.StatusCode]:
     # we use max_faces=2 not to waste time searching for more faces than we need
     # we use enforce_detection=False not to raise exception when no face found
@@ -29,26 +41,36 @@ def encode_face(
         align=align,
     )
 
-    face_confidence = float(result[0]["face_confidence"])
-
-    match (len(result), face_confidence):
-        case (l, _) if l > 1:
-            return None, Encoding.StatusCode.MULTIPLE_FACES_DETECTED
-
-        case (_, fc) if fc == 0.0:
+    match result:
+        case []:
             return None, Encoding.StatusCode.NO_FACE_DETECTED
 
-        case (_, fc) if 0.0 < fc <= 1.0 and fc < face_confidence_threshold:
-            return None, Encoding.StatusCode.FACE_NOT_ACCEPTED
+        case [_, _, *_]:
+            return None, Encoding.StatusCode.MULTIPLE_FACES_DETECTED
 
-        case _:
-            return result[0]["embedding"], None
+        case [face]:
+            fc = float(face.get("face_confidence") or 0.0)
+            match fc:
+                case 0.0:
+                    return None, Encoding.StatusCode.NO_FACE_DETECTED
+                case _ if fc < face_confidence_threshold:
+                    return None, Encoding.StatusCode.FACE_NOT_ACCEPTED
+                case _:
+                    if not (fa0 := face.get("facial_area")):
+                        return None, Encoding.StatusCode.GENERIC_ERROR
+                    fa = {**fa0, "img_w": data.shape[1], "img_h": data.shape[0]}
+                    if not is_face_coverage(coverage_threshold=face_coverage_threshold, fa=fa):
+                        return None, Encoding.StatusCode.INSUFFICIENT_FACE_COVERAGE
+                    return face["embedding"], None
+
+    return None, Encoding.StatusCode.GENERIC_ERROR
 
 
 def encode_faces(  # noqa: PLR0913
     ds: DeduplicationSet,
     encoding_ids: list[UUID],
     face_confidence_threshold: float,
+    face_coverage_threshold: float,
     model_name: str,
     detector_backend: str,
     align: bool,
@@ -65,6 +87,7 @@ def encode_faces(  # noqa: PLR0913
                 encoding.embedding, encoding.embedding_status_code = encode_face(
                     storage.load_image(encoding.filename),
                     face_confidence_threshold,
+                    face_coverage_threshold,
                     model_name,
                     detector_backend,
                     align,

--- a/src/hope_dedup_engine/config/fragments/constance.py
+++ b/src/hope_dedup_engine/config/fragments/constance.py
@@ -26,6 +26,12 @@ CONSTANCE_CONFIG = {
         "or partially visible faces to pass.",
         "bounded_confidence_0_1",
     ),
+    "DEFAULT_FACE_COVERAGE_THRESHOLD": (
+        0.25,
+        "Minimum ratio of the image area (0..1) that must be covered by the detected face bounding box. "
+        "Faces smaller than this ratio are rejected.",
+        "bounded_confidence_0_1",
+    ),
     "DEFAULT_DUPLICATE_CONFIDENCE_THRESHOLD": (
         0.5,
         "Threshold on the face match confidence score (0..1). "
@@ -55,6 +61,7 @@ CONSTANCE_CONFIG_FIELDSETS = {
             "DEFAULT_DETECTOR_BACKEND",
             "DEFAULT_DISTANCE_METRIC",
             "DEFAULT_FACE_DETECTION_CONFIDENCE_THRESHOLD",
+            "DEFAULT_FACE_COVERAGE_THRESHOLD",
             "DEFAULT_DUPLICATE_CONFIDENCE_THRESHOLD",
         ),
         "collapse": False,

--- a/tests/apps/faces/services/test_facial.py
+++ b/tests/apps/faces/services/test_facial.py
@@ -1,5 +1,5 @@
 import copy
-
+import numpy as np
 import pytest
 from azure.core.exceptions import ResourceNotFoundError
 
@@ -17,10 +17,16 @@ def mock_deepface(mocker):
 
 
 @pytest.fixture
-def mock_storage(mocker):
+def sample_image() -> np.ndarray:
+    """Sample image data for face encoding tests."""
+    return np.zeros((300, 300, 3), dtype=np.uint8)
+
+
+@pytest.fixture
+def mock_storage(mocker, sample_image):
     """Fixture to mock the ImagesStorageManager."""
     storage_mock = mocker.patch("hope_dedup_engine.apps.faces.services.facial.ImagesStorageManager").return_value
-    storage_mock.load_image.return_value = "image_data"
+    storage_mock.load_image.return_value = sample_image
     return storage_mock
 
 
@@ -49,11 +55,11 @@ def test_encode_faces_success(mock_deepface, mock_storage, deduplication_set_fac
     encoding0 = encoding_factory(deduplication_set=deduplication_set, filename="file1.jpg", embedding=None)
     encoding1 = encoding_factory(deduplication_set=deduplication_set, filename="file2.jpg", embedding=None)
     mock_deepface.represent.side_effect = [
-        [{"embedding": [1.0], "face_confidence": 0.1}],
-        [{"embedding": [2.0], "face_confidence": 0.1}],
+        [{"embedding": [1.0], "face_confidence": 0.1, "facial_area": {"x": 0, "y": 0, "w": 120, "h": 170}}],
+        [{"embedding": [2.0], "face_confidence": 0.1, "facial_area": {"x": 0, "y": 0, "w": 120, "h": 170}}],
     ]
 
-    encode_faces(deduplication_set, [encoding0.id, encoding1.id], 0.1, "model", "backend", True)
+    encode_faces(deduplication_set, [encoding0.id, encoding1.id], 0.1, 0.0, "model", "backend", True)
 
     encoding0.refresh_from_db()
     encoding1.refresh_from_db()
@@ -95,6 +101,15 @@ def test_encode_faces_success(mock_deepface, mock_storage, deduplication_set_fac
             },
             Encoding.StatusCode.FACE_NOT_ACCEPTED,
         ),
+        # 5) missing facial_area -> GENERIC_ERROR
+        (
+            {
+                "return_value": [
+                    {"embedding": [1.0], "face_confidence": 0.99},
+                ]
+            },
+            Encoding.StatusCode.GENERIC_ERROR,
+        ),
     ],
 )
 @pytest.mark.django_db
@@ -105,7 +120,7 @@ def test_encode_faces_deepface_outcomes(
     encoding = encoding_factory(filename="file1.jpg", embedding=None)
     mock_deepface.represent.configure_mock(**represent_kwargs)
 
-    encode_faces(encoding.deduplication_set, [encoding.id], 0.9, "model", "backend", True)
+    encode_faces(encoding.deduplication_set, [encoding.id], 0.9, 0.0, "model", "backend", True)
 
     encoding.refresh_from_db()
     assert encoding.embedding_status_code == expected_status.value
@@ -117,7 +132,7 @@ def test_encode_faces_file_not_found(mock_deepface, mock_storage, encoding_facto
     encoding = encoding_factory(filename="file1.jpg", embedding=None)
     mock_storage.load_image.side_effect = ResourceNotFoundError("File not found")
 
-    encode_faces(encoding.deduplication_set, [encoding.id], 0.9, "model", "backend", True)
+    encode_faces(encoding.deduplication_set, [encoding.id], 0.9, 0.0, "model", "backend", True)
 
     encoding.refresh_from_db()
     assert encoding.embedding_status_code == Encoding.StatusCode.FILE_NOT_FOUND.value
@@ -193,3 +208,31 @@ def test_dedupe_images_complex_scenario(mock_deepface, complex_deduplication_dat
 
     with pytest.raises(StopIteration):
         mock_deepface.verify()
+
+
+@pytest.mark.django_db
+def test_encode_faces_insufficient_face_coverage(mock_deepface, mock_storage, encoding_factory):
+    encoding = encoding_factory(filename="file1.jpg", embedding=None)
+    mock_storage.load_image.return_value = np.zeros((300, 300, 3), dtype=np.uint8)
+    mock_deepface.represent.return_value = [
+        {
+            "embedding": [1.0],
+            "face_confidence": 0.99,
+            "facial_area": {"x": 0, "y": 0, "w": 10, "h": 10},
+        }
+    ]
+
+    encode_faces(
+        encoding.deduplication_set,
+        [encoding.id],
+        0.1,
+        0.05,
+        "model",
+        "backend",
+        align=True,
+    )
+
+    encoding.refresh_from_db()
+    assert encoding.embedding is None
+    assert encoding.embedding_status_code == Encoding.StatusCode.INSUFFICIENT_FACE_COVERAGE.value
+    mock_deepface.represent.assert_called_once()

--- a/tests/apps/faces/test_celery_tasks.py
+++ b/tests/apps/faces/test_celery_tasks.py
@@ -103,7 +103,7 @@ def test_encode_chunk_success(mock_encode_faces, mock_get_ds, dedup_set_with_job
     encode_chunk(ds.pk, [encoding.pk])
 
     mock_encode_faces.assert_called_once_with(
-        dedup_set_with_job, [encoding.pk], 0.9, "Facenet512", "retinaface", align=True
+        dedup_set_with_job, [encoding.pk], 0.9, 0.25, "Facenet512", "retinaface", align=True
     )
 
 


### PR DESCRIPTION
Add face coverage threshold to DeepFace encoding pipeline
[AB#290618](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/290618)