### PR TITLE
AB#291452: Deduplication Set API view

### DIFF
--- a/src/hope_dedup_engine/apps/api/serializers.py
+++ b/src/hope_dedup_engine/apps/api/serializers.py
@@ -31,6 +31,11 @@ class DeduplicationSetSerializer(serializers.ModelSerializer):
         )
 
     def get_status(self, deduplication_set: DeduplicationSet) -> str:
+        # EncodeChunkJob and DeduplicateDatasetJob are created inside the
+        # DedupJob. DedupeChunkJob and CallbackFindingsJob are created inside
+        # the DeduplicateDatasetJob. So we always have the next job object
+        # created before the current job is finished
+
         job_managers = (
             deduplication_set.dedup_jobs,
             deduplication_set.encode_chunk_jobs,
@@ -45,15 +50,23 @@ class DeduplicationSetSerializer(serializers.ModelSerializer):
             job = job_manager.order_by("-id").first()
 
             if job is None:
+                # we only get here if no job was scheduled or the previous task
+                # finished without being able to create the next task, which
+                # means some other failure
                 return CeleryTaskModel.NOT_SCHEDULED
 
             if (result := job.async_result) is None:
+                # job record was created but the task is not yet started
                 if first_task:
                     return CeleryTaskModel.PENDING
+
+                # we had some tasks finished before
                 return CeleryTaskModel.STARTED
 
             first_task = False
 
+            # if the current task status is SUCCESS, we need to check the next
+            # one
             if (status := result.status) != CeleryTaskModel.SUCCESS:
                 return status
 

--- a/src/hope_dedup_engine/apps/api/serializers.py
+++ b/src/hope_dedup_engine/apps/api/serializers.py
@@ -1,6 +1,7 @@
 from itertools import filterfalse
 from typing import Any
 
+from django_celery_boost.models import CeleryTaskModel
 from rest_framework import serializers
 
 from hope_dedup_engine.apps.api.models import (
@@ -16,6 +17,7 @@ class DeduplicationSetSerializer(serializers.ModelSerializer):
     reference_pk = serializers.CharField(source="group.reference_pk")
     name = serializers.CharField(source="group.name", read_only=True, allow_null=True)
     state = serializers.CharField(source="get_state_display", read_only=True)
+    status = serializers.SerializerMethodField()
 
     class Meta:
         model = DeduplicationSet
@@ -27,6 +29,35 @@ class DeduplicationSetSerializer(serializers.ModelSerializer):
             "updated_at",
             "updated_by",
         )
+
+    def get_status(self, deduplication_set: DeduplicationSet) -> str:
+        job_managers = (
+            deduplication_set.dedup_jobs,
+            deduplication_set.encode_chunk_jobs,
+            deduplication_set.deduplicate_dataset_jobs,
+            deduplication_set.dedupe_chunk_jobs,
+            deduplication_set.callback_findings_jobs,
+        )
+
+        first_task = True
+
+        for job_manager in job_managers:
+            job = job_manager.order_by("-id").first()
+
+            if job is None:
+                return CeleryTaskModel.NOT_SCHEDULED
+
+            if (result := job.async_result) is None:
+                if first_task:
+                    return CeleryTaskModel.PENDING
+                return CeleryTaskModel.STARTED
+
+            first_task = False
+
+            if (status := result.status) != CeleryTaskModel.SUCCESS:
+                return status
+
+        return CeleryTaskModel.SUCCESS
 
 
 class CreateDeduplicationSetSerializer(serializers.ModelSerializer):

--- a/tests/api/serializers/test_deduplication_set_serializer.py
+++ b/tests/api/serializers/test_deduplication_set_serializer.py
@@ -64,6 +64,37 @@ def test_status_when_job_started(
     assert serializer.get_status(deduplication_set) == CeleryTaskModel.STARTED
 
 
+@pytest.mark.parametrize(
+    "finished_tasks",
+    [
+        pytest.param(1, id="encode chunk job not started"),
+        pytest.param(2, id="deduplicate dataset job not started"),
+        pytest.param(3, id="dedupe chunk job not started"),
+        pytest.param(4, id="callback findings job not started"),
+    ],
+)
+def test_status_when_job_started_but_task_is_not(
+    mocker: MockerFixture,
+    deduplication_set: DeduplicationSet,
+    dedup_job: DedupJob,
+    encode_chunk_job: EncodeChunkJob,
+    deduplicate_dataset_job: DeduplicateDatasetJob,
+    dedupe_chunk_job: DedupeChunkJob,
+    callback_findings_job: CallbackFindingsJob,
+    finished_tasks: int,
+) -> None:
+    successful_status_mock = mocker.Mock()
+    successful_status_mock.status = CeleryTaskModel.SUCCESS
+    async_result_values = [successful_status_mock] * finished_tasks + [None]
+    mocker.patch(
+        "hope_dedup_engine.apps.api.models.jobs.CeleryTaskModel.async_result",
+        new_callable=mocker.PropertyMock,
+        side_effect=async_result_values,
+    )
+    serializer = DeduplicationSetSerializer(deduplication_set)
+    assert serializer.get_status(deduplication_set) == CeleryTaskModel.STARTED
+
+
 def test_status_when_job_finished(
     mocker: MockerFixture,
     deduplication_set: DeduplicationSet,

--- a/tests/api/serializers/test_deduplication_set_serializer.py
+++ b/tests/api/serializers/test_deduplication_set_serializer.py
@@ -1,0 +1,79 @@
+from django_celery_boost.models import CeleryTaskModel
+import pytest
+from pytest_mock import MockerFixture
+
+from hope_dedup_engine.apps.api.models import DedupJob, DeduplicationSet
+from hope_dedup_engine.apps.api.models.jobs import (
+    EncodeChunkJob,
+    DeduplicateDatasetJob,
+    DedupeChunkJob,
+    CallbackFindingsJob,
+)
+from hope_dedup_engine.apps.api.serializers import DeduplicationSetSerializer
+
+
+def test_status_when_no_job_run(deduplication_set: DeduplicationSet) -> None:
+    serializer = DeduplicationSetSerializer(deduplication_set)
+    assert serializer.get_status(deduplication_set) == CeleryTaskModel.NOT_SCHEDULED
+
+
+def test_status_when_job_queued(deduplication_set: DeduplicationSet, dedup_job: DedupJob) -> None:
+    serializer = DeduplicationSetSerializer(deduplication_set)
+    assert dedup_job.async_result is None
+    assert serializer.get_status(deduplication_set) == CeleryTaskModel.PENDING
+
+
+@pytest.mark.parametrize(
+    "job_statuses",
+    [
+        pytest.param([CeleryTaskModel.STARTED], id="dedup job started"),
+        pytest.param([CeleryTaskModel.SUCCESS, CeleryTaskModel.STARTED], id="encode chunk job started"),
+        pytest.param(
+            [CeleryTaskModel.SUCCESS, CeleryTaskModel.SUCCESS, CeleryTaskModel.STARTED],
+            id="deduplicate dataset job started",
+        ),
+        pytest.param(
+            [CeleryTaskModel.SUCCESS, CeleryTaskModel.SUCCESS, CeleryTaskModel.SUCCESS, CeleryTaskModel.STARTED],
+            id="dedupe chunk job started",
+        ),
+        pytest.param(
+            [
+                CeleryTaskModel.SUCCESS,
+                CeleryTaskModel.SUCCESS,
+                CeleryTaskModel.SUCCESS,
+                CeleryTaskModel.SUCCESS,
+                CeleryTaskModel.STARTED,
+            ],
+            id="callback findings job started",
+        ),
+    ],
+)
+def test_status_when_job_started(
+    mocker: MockerFixture,
+    deduplication_set: DeduplicationSet,
+    dedup_job: DedupJob,
+    encode_chunk_job: EncodeChunkJob,
+    deduplicate_dataset_job: DeduplicateDatasetJob,
+    dedupe_chunk_job: DedupeChunkJob,
+    callback_findings_job: CallbackFindingsJob,
+    job_statuses: list[str],
+) -> None:
+    async_result_mock = mocker.patch("hope_dedup_engine.apps.api.models.jobs.CeleryTaskModel.async_result")
+    type(async_result_mock).status = mocker.PropertyMock(side_effect=job_statuses)
+    serializer = DeduplicationSetSerializer(deduplication_set)
+    assert serializer.get_status(deduplication_set) == CeleryTaskModel.STARTED
+
+
+def test_status_when_job_finished(
+    mocker: MockerFixture,
+    deduplication_set: DeduplicationSet,
+    dedup_job: DedupJob,
+    encode_chunk_job: EncodeChunkJob,
+    deduplicate_dataset_job: DeduplicateDatasetJob,
+    dedupe_chunk_job: DedupeChunkJob,
+    callback_findings_job: CallbackFindingsJob,
+) -> None:
+    async_result_mock = mocker.patch("hope_dedup_engine.apps.api.models.jobs.CeleryTaskModel.async_result")
+    async_result_mock.status = CeleryTaskModel.SUCCESS
+    serializer = DeduplicationSetSerializer(deduplication_set)
+    assert serializer.get_status(deduplication_set) == CeleryTaskModel.SUCCESS


### PR DESCRIPTION
[AB#291452](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/291452)

Add status field to deduplication set serializer. This field reflects deduplication process status in Celery
