### PR TITLE
Hotfix: Make deduplication set settings optional

### DIFF
--- a/src/hope_dedup_engine/apps/api/serializers.py
+++ b/src/hope_dedup_engine/apps/api/serializers.py
@@ -84,7 +84,7 @@ class CreateDeduplicationSetSerializer(serializers.ModelSerializer):
     reference_pk = serializers.CharField(source="group.reference_pk")
     name = serializers.CharField(source="group.name", required=False, allow_null=True, allow_blank=True)
     state = serializers.CharField(source="get_state_display", read_only=True)
-    settings = serializers.JSONField(required=True)
+    settings = serializers.JSONField(default=dict)
 
     class Meta:
         model = DeduplicationSet


### PR DESCRIPTION
# Legal Boilerplate

Look, I get it.
Contributing to HOPE Dedup, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that HOPE Workspace can use, modify, copy, and redistribute my contributions,
under HOPE's choice of terms.
