### PR TITLE
ci: disable Trivy job in SDLC version create workflow

### DIFF
--- a/.github/workflows/sdlc-version-create.yml
+++ b/.github/workflows/sdlc-version-create.yml
@@ -86,26 +86,27 @@ jobs:
             --push \
             ./
 
-  trivy:
-    name: Check Release with Trivy
-    runs-on: ubuntu-latest
-    needs: [prepare-version, build-push]
-    permissions:
-      contents: read # for actions/checkout to fetch code
-      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.34.0
-        with:
-          image-ref: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.DOCKERHUB_REPOSITORY }}:${{ needs.prepare-version.outputs.version }}
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: 'trivy-results.sarif'
+  # Trivy release scan disabled — uncomment the job below to re-enable
+  # trivy:
+  #   name: Check Release with Trivy
+  #   runs-on: ubuntu-latest
+  #   needs: [prepare-version, build-push]
+  #   permissions:
+  #     contents: read # for actions/checkout to fetch code
+  #     security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+  #   steps:
+  #     - name: Checkout code
+  #       uses: actions/checkout@v6
+  #
+  #     - name: Run Trivy vulnerability scanner
+  #       uses: aquasecurity/trivy-action@0.34.0
+  #       with:
+  #         image-ref: ${{ vars.DOCKERHUB_ORGANIZATION }}/${{ vars.DOCKERHUB_REPOSITORY }}:${{ needs.prepare-version.outputs.version }}
+  #         format: 'sarif'
+  #         output: 'trivy-results.sarif'
+  #         severity: 'CRITICAL,HIGH'
+  #
+  #     - name: Upload Trivy scan results to GitHub Security tab
+  #       uses: github/codeql-action/upload-sarif@v4
+  #       with:
+  #         sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Comment out the release image Trivy scan job; re-enable by uncommenting the block.

Note: Branch from develop; repository has no main or master branch.
Made-with: Cursor

# Legal Boilerplate

Look, I get it.
Contributing to HOPE Dedup Engine, I retain all rights, title and interest in and to my contributions, and by keeping
this boilerplate intact I confirm that HOPE Workspace can use, modify, copy, and redistribute my contributions,
under HOPE's choice of terms.
