### PR TITLE
Block /config/ during processing and clean only ENCODED/DEDUPLICATED sets

### DIFF
--- a/src/hope_dedup_engine/apps/api/models/deduplication.py
+++ b/src/hope_dedup_engine/apps/api/models/deduplication.py
@@ -10,7 +10,6 @@ from django.db.models import Q, QuerySet
 
 from hope_dedup_engine.apps.api.utils.data_url import inline_label
 from hope_dedup_engine.apps.security.models import System
-from hope_dedup_engine.apps.api.models.jobs import MainJob
 
 REFERENCE_PK_LENGTH: Final[int] = 100
 FILENAME_LENGTH: Final[int] = 255
@@ -71,39 +70,39 @@ class DeduplicationSetGroup(models.Model):
         self.save(update_fields=["processing_locked"])
 
     def update_settings(self, new_settings: dict) -> None:
-        if self.deduplicationset_set.filter(
-            state__in=[DeduplicationSet.State.APPROVED, DeduplicationSet.State.DEDUPLICATED]
-        ).exists():
-            raise GroupSettingsError(
-                "Cannot change settings while the deduplication sets in APPROVED or DEDUPLICATED state exist."
+        if not self.acquire_processing_lock():
+            raise GroupSettingsError("Cannot change settings while a processing job is running.")
+
+        try:
+            if self.deduplicationset_set.filter(state=DeduplicationSet.State.APPROVED).exists():
+                raise GroupSettingsError("Cannot change settings while an approved deduplication set exists.")
+
+            with transaction.atomic():
+                if not self.settings:
+                    from hope_dedup_engine.apps.api.deduplication.config import get_default_group_settings  # noqa
+
+                    self.settings = get_default_group_settings()
+
+                for key, value in new_settings.items():
+                    self.settings[key] = value
+                self.save(update_fields=["settings"])
+
+                self._clear_active_set_on_settings_change()
+        finally:
+            self.release_processing_lock()
+
+    def _clear_active_set_on_settings_change(self) -> None:
+        ds = (
+            self.deduplicationset_set.filter(
+                state__in=(DeduplicationSet.State.ENCODED, DeduplicationSet.State.DEDUPLICATED)
             )
-
-        if not self.settings:
-            from hope_dedup_engine.apps.api.deduplication.config import get_default_group_settings  # noqa
-
-            self.settings = get_default_group_settings()
-
-        for key, value in new_settings.items():
-            self.settings[key] = value
-        self.save(update_fields=["settings"])
-
-        self._trigger_re_encoding()
-
-    def _trigger_re_encoding(self) -> None:
-        ds = self.deduplicationset_set.exclude(state=DeduplicationSet.State.APPROVED).order_by("-created_at").first()
-        if not ds or not ds.encodings_with_embeddings().exists():
+            .order_by("-created_at")
+            .first()
+        )
+        if not ds:
             return
-
         ds.clear_embeddings_data()
-        if self.acquire_processing_lock():
-            ds.state = DeduplicationSet.State.ENCODING_IN_PROGRESS
-            ds.error = None
-            ds.save(update_fields=["state", "error"])
-            MainJob.objects.create(deduplication_set=ds, encode_only=True).queue()
-        else:
-            ds.state = DeduplicationSet.State.READY
-            ds.error = None
-            ds.save(update_fields=["state", "error"])
+        ds.set_state(DeduplicationSet.State.READY)
 
 
 ENCODING_FAILED_STATE: Final[int] = 5
@@ -133,13 +132,13 @@ class DeduplicationSet(models.Model):
         State.UPLOADING_IN_PROGRESS: (State.UPLOADING_IN_PROGRESS, State.READY),
         State.READY: (State.ENCODING_IN_PROGRESS,),
         State.ENCODING_IN_PROGRESS: (State.ENCODED, State.ENCODING_FAILED),
-        State.ENCODED: (State.DEDUPLICATION_IN_PROGRESS, State.ENCODING_IN_PROGRESS),
+        State.ENCODED: (State.DEDUPLICATION_IN_PROGRESS, State.ENCODING_IN_PROGRESS, State.READY),
         State.ENCODING_FAILED: (State.ENCODING_IN_PROGRESS,),
         State.DEDUPLICATION_IN_PROGRESS: (State.DEDUPLICATED, State.DEDUPLICATION_FAILED),
-        State.DEDUPLICATED: (State.APPROVED, State.REJECTED),
+        State.DEDUPLICATED: (State.APPROVED, State.REJECTED, State.READY, State.ENCODED),
         State.DEDUPLICATION_FAILED: (State.DEDUPLICATION_IN_PROGRESS, State.ENCODING_IN_PROGRESS),
         State.APPROVED: (),
-        State.REJECTED: (State.READY, State.ENCODED),
+        State.REJECTED: (),
     }
 
     PROCESSABLE_STATES: Final[tuple[int, ...]] = (

--- a/src/hope_dedup_engine/apps/api/views.py
+++ b/src/hope_dedup_engine/apps/api/views.py
@@ -277,7 +277,9 @@ class DeduplicationSetGroupView(viewsets.ViewSet):
         responses=GroupSettingsSerializer,
         description="Create or update quality threshold settings for a deduplication set group. "
         "Creates the group if it does not exist. "
-        "Returns 409 if the group has an approved or deduplicated set (settings are locked).",
+        "Returns 409 if the group has an approved set or a processing job is running. "
+        "If a deduplicated or encoded set exists, its embeddings and findings are cleared "
+        "so new settings take effect on the next processing.",
     )
     @action(detail=True, methods=(HTTPMethod.GET, HTTPMethod.POST), url_path="config")
     def config(self, request: Request, reference_pk: str) -> Response:

--- a/tests/api/models/test_deduplication.py
+++ b/tests/api/models/test_deduplication.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 
 from hope_dedup_engine.apps.api.deduplication.config import get_default_group_settings
@@ -39,31 +37,11 @@ def group_with_approved_ds(group_with_settings, deduplication_set_factory):
 
 
 @pytest.fixture
-def group_ds_no_embeddings(group_with_settings, deduplication_set_factory, encoding_factory):
-    ds = deduplication_set_factory(group=group_with_settings)
-    encoding_factory(deduplication_set=ds, embedding=None, embedding_status_code=None)
-    return group_with_settings, ds
-
-
-@pytest.fixture
-def group_ds_with_embedding(group_with_settings, deduplication_set_factory, encoding_factory):
-    ds = deduplication_set_factory(group=group_with_settings)
+def group_ds_deduplicated_with_data(group_with_settings, deduplication_set_factory, encoding_factory, finding_factory):
+    ds = deduplication_set_factory(group=group_with_settings, state=DeduplicationSet.State.DEDUPLICATED)
     enc = encoding_factory(deduplication_set=ds, embedding=[0.1] * 8)
-    return group_with_settings, ds, enc
-
-
-@pytest.fixture
-def group_ds_with_embedding_and_finding(group_ds_with_embedding, finding_factory):
-    group, ds, enc = group_ds_with_embedding
     finding_factory(deduplication_set=ds, first_encoding=enc)
-    return group, ds, enc
-
-
-@pytest.fixture
-def locked_group_ds_with_embedding(group_with_settings_locked, deduplication_set_factory, encoding_factory):
-    ds = deduplication_set_factory(group=group_with_settings_locked)
-    encoding_factory(deduplication_set=ds, embedding=[0.1] * 8)
-    return group_with_settings_locked, ds
+    return group_with_settings, ds, enc
 
 
 @pytest.mark.parametrize(
@@ -79,6 +57,8 @@ def locked_group_ds_with_embedding(group_with_settings_locked, deduplication_set
         (DeduplicationSet.State.DEDUPLICATION_IN_PROGRESS, DeduplicationSet.State.DEDUPLICATION_FAILED),
         (DeduplicationSet.State.DEDUPLICATED, DeduplicationSet.State.APPROVED),
         (DeduplicationSet.State.DEDUPLICATED, DeduplicationSet.State.REJECTED),
+        (DeduplicationSet.State.DEDUPLICATED, DeduplicationSet.State.READY),
+        (DeduplicationSet.State.DEDUPLICATED, DeduplicationSet.State.ENCODED),
     ],
 )
 @pytest.mark.parametrize(
@@ -173,8 +153,37 @@ def test_encodings_without_embeddings_exclusion(
 
 @pytest.mark.django_db
 def test_update_settings_raises_when_approved_sets_exist(group_with_approved_ds):
-    with pytest.raises(GroupSettingsError, match="APPROVED or DEDUPLICATED"):
+    with pytest.raises(GroupSettingsError, match="approved"):
         group_with_approved_ds.update_settings({"sharpness_threshold": 0.5})
+
+
+@pytest.mark.django_db
+def test_update_settings_raises_when_processing_locked(group_with_settings_locked):
+    with pytest.raises(GroupSettingsError, match="processing job is running"):
+        group_with_settings_locked.update_settings({"sharpness_threshold": 0.5})
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "state",
+    [
+        DeduplicationSet.State.EMPTY,
+        DeduplicationSet.State.UPLOADING_IN_PROGRESS,
+        DeduplicationSet.State.READY,
+        DeduplicationSet.State.REJECTED,
+        DeduplicationSet.State.ENCODING_FAILED,
+        DeduplicationSet.State.DEDUPLICATION_FAILED,
+    ],
+)
+def test_update_settings_allowed_for_states_without_data_to_clean(
+    group_with_settings, deduplication_set_factory, state
+):
+    """Settings change is allowed for states with no embeddings to clean."""
+    deduplication_set_factory(group=group_with_settings, state=state)
+    group_with_settings.update_settings({"sharpness_threshold": 0.7})
+
+    group_with_settings.refresh_from_db()
+    assert group_with_settings.settings["sharpness_threshold"] == 0.7
 
 
 @pytest.mark.django_db
@@ -200,51 +209,65 @@ def test_update_settings_initializes_defaults_when_settings_is_none(group_with_s
 
 
 @pytest.mark.django_db
-def test_trigger_re_encoding_noop_when_no_dedup_sets(group_with_settings):
-    group_with_settings._trigger_re_encoding()
-
+def test_clear_active_set_noop_when_no_dedup_sets(group_with_settings):
+    group_with_settings._clear_active_set_on_settings_change()
     assert not group_with_settings.processing_locked
 
 
 @pytest.mark.django_db
-def test_trigger_re_encoding_noop_when_no_embeddings(group_ds_no_embeddings):
-    group, ds = group_ds_no_embeddings
-
-    group._trigger_re_encoding()
+@pytest.mark.parametrize(
+    "state",
+    [
+        DeduplicationSet.State.EMPTY,
+        DeduplicationSet.State.UPLOADING_IN_PROGRESS,
+        DeduplicationSet.State.READY,
+        DeduplicationSet.State.REJECTED,
+        DeduplicationSet.State.ENCODING_FAILED,
+        DeduplicationSet.State.DEDUPLICATION_FAILED,
+    ],
+)
+def test_clear_active_set_noop_for_non_cleanable_states(group_with_settings, deduplication_set_factory, state):
+    """Cleanup only targets ENCODED/DEDUPLICATED sets; other states are left alone."""
+    ds = deduplication_set_factory(group=group_with_settings, state=state)
+    group_with_settings._clear_active_set_on_settings_change()
 
     ds.refresh_from_db()
-    assert ds.state == DeduplicationSet.State.READY
-    assert not group.processing_locked
+    assert ds.state == state
 
 
 @pytest.mark.django_db
-@patch("hope_dedup_engine.apps.api.models.jobs.MainJob.objects.create")
-def test_trigger_re_encoding_clears_data_and_queues_job_when_lock_acquired(
-    mock_create, group_ds_with_embedding_and_finding
+@pytest.mark.parametrize(
+    "state",
+    [
+        DeduplicationSet.State.ENCODED,
+        DeduplicationSet.State.DEDUPLICATED,
+    ],
+)
+def test_clear_active_set_clears_data_and_transitions_to_ready(
+    group_with_settings, deduplication_set_factory, encoding_factory, finding_factory, state
 ):
-    mock_job = mock_create.return_value
-    group, ds, enc = group_ds_with_embedding_and_finding
+    ds = deduplication_set_factory(group=group_with_settings, state=state)
+    enc = encoding_factory(deduplication_set=ds, embedding=[0.1] * 8)
+    if state == DeduplicationSet.State.DEDUPLICATED:
+        finding_factory(deduplication_set=ds, first_encoding=enc)
 
-    group._trigger_re_encoding()
+    group_with_settings._clear_active_set_on_settings_change()
 
     enc.refresh_from_db()
     assert enc.embedding is None
     assert ds.finding_set.count() == 0
     ds.refresh_from_db()
-    assert ds.state == DeduplicationSet.State.ENCODING_IN_PROGRESS
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["encode_only"] is True
-    mock_job.queue.assert_called_once()
+    assert ds.state == DeduplicationSet.State.READY
 
 
 @pytest.mark.django_db
-@patch("hope_dedup_engine.apps.api.models.jobs.MainJob.objects.create")
-def test_trigger_re_encoding_resets_to_ready_when_lock_not_acquired(mock_create, locked_group_ds_with_embedding):
-    group, ds = locked_group_ds_with_embedding
+def test_update_settings_full_flow_clears_deduplicated_set(group_ds_deduplicated_with_data):
+    group, ds, enc = group_ds_deduplicated_with_data
 
-    group._trigger_re_encoding()
+    group.update_settings({"sharpness_threshold": 0.4})
 
+    enc.refresh_from_db()
+    assert enc.embedding is None
+    assert ds.finding_set.count() == 0
     ds.refresh_from_db()
     assert ds.state == DeduplicationSet.State.READY
-    assert ds.error is None
-    mock_create.assert_not_called()

--- a/tests/api/test_group_config.py
+++ b/tests/api/test_group_config.py
@@ -1,5 +1,3 @@
-from unittest.mock import patch
-
 import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -130,9 +128,7 @@ def test_post_blocked_when_approved_dedup_set_exists(
 
 
 @pytest.mark.django_db
-@patch("hope_dedup_engine.apps.api.views.MainJob.objects.create")
-def test_post_clears_embeddings_and_triggers_reencoding(
-    mock_create,
+def test_post_clears_deduplicated_set_data(
     api_client: APIClient,
     hde_token,
     deduplication_set_group_factory,
@@ -140,12 +136,11 @@ def test_post_clears_embeddings_and_triggers_reencoding(
     encoding_factory,
     finding_factory,
 ):
-    mock_job = mock_create.return_value
     group = deduplication_set_group_factory(system=hde_token.system)
     group.settings = get_default_group_settings()
     group.save()
 
-    ds = deduplication_set_factory(group=group)
+    ds = deduplication_set_factory(group=group, state=DeduplicationSet.State.DEDUPLICATED)
     encoding = encoding_factory(deduplication_set=ds, embedding=[0.1] * 8)
     finding_factory(deduplication_set=ds, first_encoding=encoding)
 
@@ -155,7 +150,30 @@ def test_post_clears_embeddings_and_triggers_reencoding(
     encoding.refresh_from_db()
     assert encoding.embedding is None
     assert ds.finding_set.count() == 0
+    ds.refresh_from_db()
+    assert ds.state == DeduplicationSet.State.READY
 
-    mock_create.assert_called_once()
-    assert mock_create.call_args.kwargs["encode_only"] is True
-    mock_job.queue.assert_called_once()
+
+@pytest.mark.django_db
+def test_post_allowed_when_only_ready_set_exists(
+    api_client: APIClient, hde_token, deduplication_set_group_factory, deduplication_set_factory
+):
+    """READY set has no embeddings to clean; settings change is allowed."""
+    group = deduplication_set_group_factory(system=hde_token.system)
+    group.settings = get_default_group_settings()
+    group.save()
+    deduplication_set_factory(group=group, state=DeduplicationSet.State.READY)
+
+    response = api_client.post(config_url(group.reference_pk), data={"sharpness_threshold": 0.5}, format=JSON)
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_post_blocked_when_processing_locked(api_client: APIClient, hde_token, deduplication_set_group_factory):
+    group = deduplication_set_group_factory(system=hde_token.system)
+    group.settings = get_default_group_settings()
+    group.processing_locked = True
+    group.save()
+
+    response = api_client.post(config_url(group.reference_pk), data={"sharpness_threshold": 0.5}, format=JSON)
+    assert response.status_code == status.HTTP_409_CONFLICT


### PR DESCRIPTION
[AB#311447](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/311447)


- Block /config/ API endpoint when a processing job is running for the group (returns 409)
- Settings change now cleans embeddings and findings only for the active set in ENCODED or DEDUPLICATED state, transitioning it to READY
- Stop triggering the re-encoding job automatically on settings change — re-encoding will be performed by the next /process/ call
- Make update_settings race-safe by using acquire_processing_lock so concurrent /process/ calls cannot start while settings are being applied
- Add DEDUPLICATED → READY and DEDUPLICATED → ENCODED to VALID_TRANSITIONS so the new cleanup path is allowed under normal validation
- REJECTED is now truly terminal