### PR TITLE
Fix slow loading of Findings and Encodings pages.

### DIFF
--- a/src/hope_dedup_engine/apps/api/admin/encoding/admin.py
+++ b/src/hope_dedup_engine/apps/api/admin/encoding/admin.py
@@ -111,10 +111,7 @@ class EncodingAdmin(BaseModelAdmin):
 
     @display(description="Filename", ordering="filename")
     def filename_pretty(self, obj: Encoding) -> str:
-        label = getattr(obj, "_filename_label", None)
-        if label is None:
-            label = obj.filename
-        return inline_label(label)
+        return inline_label(getattr(obj, "_filename_label", obj.filename))
 
     @display(description="Image quality scores")
     def image_quality_scores_sorted(self, obj: Encoding) -> str:

--- a/src/hope_dedup_engine/apps/api/admin/encoding/admin.py
+++ b/src/hope_dedup_engine/apps/api/admin/encoding/admin.py
@@ -6,7 +6,8 @@ from adminfilters.filters import LinkedAutoCompleteFilter
 from adminfilters.dates import DateInDateRangeFilter
 from adminfilters.filters import DjangoLookupFilter
 from django.contrib.admin import register, display
-from django.db.models import QuerySet
+from django.db.models import Case, F, QuerySet, TextField, When
+from django.db.models.functions import Substr
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse
@@ -95,11 +96,25 @@ class EncodingAdmin(BaseModelAdmin):
     actions = ["deduplicate_selected_encodings"]
 
     def get_queryset(self, request: HttpRequest) -> QuerySet[Encoding]:
-        return super().get_queryset(request).defer("embedding")
+        return (
+            super()
+            .get_queryset(request)
+            .defer("embedding", "filename")
+            .annotate(
+                _filename_label=Case(
+                    When(filename__startswith="data:", then=Substr("filename", 1, 200)),
+                    default=F("filename"),
+                    output_field=TextField(),
+                )
+            )
+        )
 
     @display(description="Filename", ordering="filename")
     def filename_pretty(self, obj: Encoding) -> str:
-        return inline_label(obj.filename)
+        label = getattr(obj, "_filename_label", None)
+        if label is None:
+            label = obj.filename
+        return inline_label(label)
 
     @display(description="Image quality scores")
     def image_quality_scores_sorted(self, obj: Encoding) -> str:

--- a/src/hope_dedup_engine/apps/api/admin/finding/admin.py
+++ b/src/hope_dedup_engine/apps/api/admin/finding/admin.py
@@ -55,6 +55,19 @@ class FindingAdmin(BaseModelAdmin):
     def has_delete_permission(self, request, obj=None):
         return obj is not None
 
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("first_encoding", "second_encoding")
+            .defer(
+                "first_encoding__embedding",
+                "first_encoding__filename",
+                "second_encoding__embedding",
+                "second_encoding__filename",
+            )
+        )
+
     def get_urls(self):
         return [
             path(

--- a/src/hope_dedup_engine/apps/api/admin/finding/views.py
+++ b/src/hope_dedup_engine/apps/api/admin/finding/views.py
@@ -50,7 +50,10 @@ class FindingPreviewView(FindingDetailsPermissionMixin, TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         finding = get_object_or_404(
-            Finding.objects.select_related("first_encoding", "second_encoding"),
+            Finding.objects.select_related("first_encoding", "second_encoding").defer(
+                "first_encoding__embedding",
+                "second_encoding__embedding",
+            ),
             pk=self.kwargs["pk"],
         )
         first, second = finding.first_encoding, finding.second_encoding

--- a/src/hope_dedup_engine/apps/api/models/deduplication.py
+++ b/src/hope_dedup_engine/apps/api/models/deduplication.py
@@ -8,7 +8,6 @@ from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models, transaction
 from django.db.models import Q, QuerySet
 
-from hope_dedup_engine.apps.api.utils.data_url import inline_label
 from hope_dedup_engine.apps.security.models import System
 
 REFERENCE_PK_LENGTH: Final[int] = 100
@@ -320,7 +319,7 @@ class Encoding(models.Model):
         ]
 
     def __str__(self) -> str:
-        return f"Image {inline_label(self.filename)}"
+        return f"Image {self.reference_pk}"
 
 
 class EncodingErrorGroup:
@@ -383,6 +382,6 @@ class Finding(models.Model):
         ]
 
     def __str__(self) -> str:
-        first = inline_label(self.first_encoding.filename)
-        second = inline_label(self.second_encoding.filename) if self.second_encoding else "—"
+        first = self.first_encoding.reference_pk if self.first_encoding_id else "—"
+        second = self.second_encoding.reference_pk if self.second_encoding_id else "—"
         return f"Finding({first}, {second})"

--- a/src/hope_dedup_engine/web/static/api/encoding/threshold_results.css
+++ b/src/hope_dedup_engine/web/static/api/encoding/threshold_results.css
@@ -1,3 +1,12 @@
+#threshold-results img {
+    display: block;
+    max-width: 100%;
+    max-height: 70vh;
+    height: auto;
+    object-fit: contain;
+    margin-bottom: 1rem;
+}
+
 #threshold-results form {
     margin: 1rem;
 }

--- a/tests/api/admin/test_api_admin_encoding_admin.py
+++ b/tests/api/admin/test_api_admin_encoding_admin.py
@@ -17,6 +17,33 @@ from hope_dedup_engine.apps.api.models import Encoding
 
 
 @pytest.mark.parametrize(
+    "filename_label, filename, expected",
+    [
+        (
+            "data:image/jpeg;base64,/9j/4AAQ...",
+            "data:image/jpeg;base64,/9j/4AAQ...(megabytes)",
+            "image/jpeg:<binary-data>",
+        ),
+        (None, "photos/face.jpg", "photos/face.jpg"),
+        ("photos/face.jpg", "ignored", "photos/face.jpg"),
+    ],
+    ids=[
+        "annotation_present_data_url",
+        "annotation_missing_falls_back_to_filename",
+        "annotation_present_regular_path",
+    ],
+)
+def test_filename_pretty(filename_label: str | None, filename: str, expected: str, mocker: MockerFixture) -> None:
+    encoding = mocker.Mock(spec=Encoding, filename=filename)
+    if filename_label is not None:
+        encoding._filename_label = filename_label
+    else:
+        del encoding._filename_label
+    admin = EncodingAdmin(Encoding, AdminSite())
+    assert admin.filename_pretty(encoding) == expected
+
+
+@pytest.mark.parametrize(
     "scores, expected",
     [
         (None, "N/A"),


### PR DESCRIPTION
[AB#316369](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/316369)

Optimize queries for findings and encodings pages in admin interface
Fix image size issue in encodings