### PR TITLE
Fix file permission issue with azure file storage

### DIFF
--- a/docker/bin/docker-entrypoint.sh
+++ b/docker/bin/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ -d "${DEFAULT_ROOT}" ];then
 fi
 
 if [ -d "${IMAGES_ROOT}" ];then
-  chown -R hope:unicef ${IMAGES_ROOT}
+  chown -R hope:unicef ${IMAGES_ROOT} 2>/dev/null || true
 fi
 
 if [ -d "${DEEPFACE_HOME}" ];then

--- a/docker/bin/docker-entrypoint.sh
+++ b/docker/bin/docker-entrypoint.sh
@@ -14,7 +14,7 @@ if [ -d "${DEFAULT_ROOT}" ];then
 fi
 
 if [ -d "${IMAGES_ROOT}" ];then
-  chown -R hope:unicef ${IMAGES_ROOT} 2>/dev/null || true
+  chown -R hope:unicef ${IMAGES_ROOT} 2>/dev/null || echo "WARNING: Skipping chown for ${IMAGES_ROOT}; Azure Files SMB does not support ownership changes."
 fi
 
 if [ -d "${DEEPFACE_HOME}" ];then

--- a/src/hope_dedup_engine/config/settings.py
+++ b/src/hope_dedup_engine/config/settings.py
@@ -92,6 +92,12 @@ STORAGES["default"].get("OPTIONS", {}).update({"location": DEFAULT_ROOT})
 IMAGES_ROOT = env("IMAGES_ROOT")
 STORAGES["images"].setdefault("OPTIONS", {}).update({"location": IMAGES_ROOT})
 
+# Azure Files (SMB) mounts do not support chmod/chown syscalls.  Setting
+# FILE_UPLOAD_PERMISSIONS to None tells Django's FileSystemStorage to skip
+# the os.chmod() call after saving a file.  The other storage backends
+# (Azure Blob) ignore this setting entirely.
+FILE_UPLOAD_PERMISSIONS = None
+
 SECRET_KEY = env("SECRET_KEY")
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
 


### PR DESCRIPTION
## Summary
- Set `FILE_UPLOAD_PERMISSIONS = None` in Django settings to skip the `os.chmod()` call that `FileSystemStorage._save()` makes after writing files. Azure Files (SMB) mounts do not support POSIX `chmod`/`chown` syscalls, causing `PermissionError: [Errno 1] Operation not permitted` on every image upload.
- Guard `chown` in `docker-entrypoint.sh` so it doesn't fail container startup on SMB-backed volumes.
## Root cause
Django 2.2+ defaults `FILE_UPLOAD_PERMISSIONS` to `0o644`, which forces an `os.chmod()` after every file save in `FileSystemStorage`. On the dev environment, `/var/data` is a PVC backed by Azure Files (`file.csi.azure.com`) over SMB, which rejects `chmod` with `EPERM`. Permissions on SMB mounts are controlled at mount time via `file_mode`/`dir_mode` options, making the `chmod` call both redundant and harmful.
