### PR TITLE
Use precalculated OFIQ scores when available

### DIFF
--- a/src/hope_dedup_engine/apps/faces/services/facial.py
+++ b/src/hope_dedup_engine/apps/faces/services/facial.py
@@ -13,7 +13,7 @@ from numpy import ndarray
 
 from hope_dedup_engine.apps.api.models import Encoding, Finding, DeduplicationSet
 from hope_dedup_engine.apps.api.utils.image import load_image
-from hope_dedup_engine.apps.faces.services.quality import get_active_thresholds, check_image_quality
+from hope_dedup_engine.apps.faces.services.quality import check_image_quality, get_active_thresholds
 
 if TYPE_CHECKING:
     from uuid import UUID
@@ -58,6 +58,45 @@ def encode_face(
     return None, Encoding.StatusCode.GENERIC_ERROR
 
 
+def process_encoding(
+    encoding: Encoding,
+    ofiq: OFIQ | None,
+    config: DeduplicationSetConfig,
+    active_thresholds: dict[str, float],
+) -> Encoding:
+    encoding.embedding_status_code = None
+    image_data = None
+
+    if active_thresholds:
+        if encoding.image_quality_scores is None:
+            image_data = load_image(encoding.filename)
+
+        qr = check_image_quality(
+            ofiq,
+            image_data,
+            active_thresholds,
+            cached_scores=encoding.image_quality_scores,
+        )
+        encoding.image_quality_scores = qr.scores
+
+        if not qr.face_detected:
+            encoding.embedding_status_code = Encoding.StatusCode.NO_FACE_DETECTED
+        elif not qr.passed:
+            encoding.embedding_status_code = Encoding.StatusCode.BAD_IMAGE_QUALITY
+
+    if encoding.embedding_status_code is None:
+        if image_data is None:
+            image_data = load_image(encoding.filename)
+        encoding.embedding, encoding.embedding_status_code = encode_face(
+            image_data,
+            config.face_detection_confidence_threshold,
+            config.recognition_model,
+            config.detector_backend,
+        )
+
+    return encoding
+
+
 def encode_faces(
     ds: DeduplicationSet,
     encoding_ids: list[UUID],
@@ -74,27 +113,7 @@ def encode_faces(
     for encoding in encodings:
         with transaction.atomic():
             try:
-                encoding.embedding_status_code = None
-                encoding.image_quality_scores = None
-                image_data = load_image(encoding.filename)
-
-                if ofiq is not None:
-                    qr = check_image_quality(ofiq, image_data, active_thresholds)
-                    encoding.image_quality_scores = qr.scores
-
-                    if not qr.face_detected:
-                        encoding.embedding_status_code = Encoding.StatusCode.NO_FACE_DETECTED
-                    elif not qr.passed:
-                        encoding.embedding_status_code = Encoding.StatusCode.BAD_IMAGE_QUALITY
-
-                if encoding.embedding_status_code is None:
-                    encoding.embedding, encoding.embedding_status_code = encode_face(
-                        image_data,
-                        config.face_detection_confidence_threshold,
-                        config.recognition_model,
-                        config.detector_backend,
-                    )
-
+                process_encoding(encoding, ofiq, config, active_thresholds)
             except FileNotFoundError:
                 encoding.embedding_status_code = Encoding.StatusCode.FILE_NOT_FOUND.value
             except Exception as e:

--- a/src/hope_dedup_engine/apps/faces/services/quality.py
+++ b/src/hope_dedup_engine/apps/faces/services/quality.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
+
 from hope_dedup_engine.apps.api.deduplication.config import DeduplicationSetConfig
-from ofiq import FaceDetectionError
-from ofiq import OFIQ
+from ofiq import FaceDetectionError, OFIQ
 
 import cv2
 
@@ -32,25 +32,59 @@ def get_active_thresholds(config: DeduplicationSetConfig) -> dict[str, float]:
     }
 
 
-def check_image_quality(
+def compute_ofiq_scores(
     ofiq: OFIQ,
     image_bgr: ndarray,
-    thresholds: dict[str, float],
-) -> QualityCheckResult:
-    """Run OFIQ quality assessment and check against thresholds."""
+) -> tuple[dict[str, float | None], bool]:
+    """Run OFIQ and return normalized 0-1 scores with face-detected flag.
+
+    Returns ``({}, False)`` when OFIQ cannot find a face.
+    """
     image_rgb = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2RGB)
 
     try:
-        scores = ofiq.vector_quality(image_rgb)
+        raw_scores = ofiq.vector_quality(image_rgb)
     except FaceDetectionError:
-        return QualityCheckResult(passed=False, face_detected=False)
+        return {}, False
 
-    passed = all(
-        (actual := scores.get(metric_name)) is not None and actual >= min_score
+    scores = {key: value / 100 if value is not None else value for key, value in raw_scores.items()}
+    return scores, True
+
+
+def evaluate_quality_thresholds(
+    scores: dict[str, float | None],
+    thresholds: dict[str, float],
+) -> bool:
+    """Compare cached 0-1 scores against 0-100 config thresholds.
+
+    Returns ``True`` when all active thresholds pass or *thresholds* is empty.
+    """
+    if not thresholds:
+        return True
+    return all(
+        (actual := scores.get(metric_name)) is not None and actual >= min_score / 100
         for metric_name, min_score in thresholds.items()
     )
 
-    return QualityCheckResult(
-        passed=passed,
-        scores={key: value / 100 if value else value for key, value in scores.items()},
-    )
+
+def check_image_quality(
+    ofiq: OFIQ,
+    image_bgr: ndarray | None,
+    thresholds: dict[str, float],
+    cached_scores: dict[str, float | None] | None = None,
+) -> QualityCheckResult:
+    """Assess image quality, computing OFIQ scores or reusing cached ones.
+
+    When *cached_scores* is provided it is reused as-is (an empty dict means a
+    previous OFIQ run found no face); otherwise OFIQ runs on *image_bgr*.
+    """
+    if cached_scores is not None:
+        scores, face_detected = cached_scores, bool(cached_scores)
+    else:
+        scores, face_detected = compute_ofiq_scores(ofiq, image_bgr)
+
+    if not face_detected:
+        return QualityCheckResult(passed=False, face_detected=False, scores=scores)
+
+    passed = evaluate_quality_thresholds(scores, thresholds)
+    return QualityCheckResult(passed=passed, scores=scores)

--- a/tests/apps/faces/services/test_facial.py
+++ b/tests/apps/faces/services/test_facial.py
@@ -79,6 +79,24 @@ def call_encode_face(mock_deepface, sample_image):
     return _call
 
 
+@pytest.fixture
+def encoding_no_scores(encoding_factory):
+    """Encoding awaiting its first encode: no cached quality scores."""
+    return encoding_factory(filename="file.jpg", embedding=None, image_quality_scores=None)
+
+
+@pytest.fixture
+def encoding_empty_scores(encoding_factory):
+    """Encoding whose cached scores are empty (OFIQ previously found no face)."""
+    return encoding_factory(filename="file.jpg", embedding=None, image_quality_scores={})
+
+
+@pytest.fixture
+def encoding_with_scores(encoding_factory):
+    """Encoding with cached OFIQ scores from a previous run."""
+    return encoding_factory(filename="file.jpg", embedding=None, image_quality_scores={"Sharpness": 0.8})
+
+
 # --- encode_face ----------------------------------------------------------------------------------
 
 
@@ -176,33 +194,31 @@ def test_encode_faces_success(mock_deepface, mock_storage, deduplication_set_fac
 )
 @pytest.mark.django_db
 def test_encode_faces_deepface_outcomes(
-    mock_deepface, mock_storage, encoding_factory, represent_kwargs, expected_status
+    mock_deepface, mock_storage, encoding_no_scores, represent_kwargs, expected_status
 ):
     """Test encode_faces persists status codes for represent outcomes."""
-    encoding = encoding_factory(filename="file1.jpg", embedding=None)
     mock_deepface.represent.configure_mock(**represent_kwargs)
 
     config = make_encode_config(fc_th=0.9)
-    encode_faces(encoding.deduplication_set, [encoding.id], config)
+    encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], config)
 
-    encoding.refresh_from_db()
-    assert encoding.embedding_status_code == expected_status.value
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding_status_code == expected_status.value
 
-    finding = encoding.deduplication_set.finding_set.first()
+    finding = encoding_no_scores.deduplication_set.finding_set.first()
     assert finding is not None
     assert finding.config == config.as_dict()
 
 
 @pytest.mark.django_db
-def test_encode_faces_file_not_found(mock_deepface, mock_storage, encoding_factory):
+def test_encode_faces_file_not_found(mock_deepface, mock_storage, encoding_no_scores):
     """Test handling of FileNotFoundError from storage."""
-    encoding = encoding_factory(filename="file1.jpg", embedding=None)
     mock_storage.side_effect = FileNotFoundError("File not found")
 
-    encode_faces(encoding.deduplication_set, [encoding.id], make_encode_config(fc_th=0.9))
+    encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], make_encode_config(fc_th=0.9))
 
-    encoding.refresh_from_db()
-    assert encoding.embedding_status_code == Encoding.StatusCode.FILE_NOT_FOUND.value
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding_status_code == Encoding.StatusCode.FILE_NOT_FOUND.value
     mock_deepface.represent.assert_not_called()
 
 
@@ -496,69 +512,126 @@ def make_config_with_ofiq(sharpness: int = 50, fc_th: float = 0.9) -> Deduplicat
 
 
 @pytest.mark.django_db
-def test_encode_faces_skips_ofiq_when_no_thresholds(mock_deepface, mock_storage, encoding_factory):
-    encoding = encoding_factory(filename="file.jpg", embedding=None)
+def test_encode_faces_skips_ofiq_when_no_thresholds(mock_deepface, mock_storage, encoding_no_scores):
     mock_deepface.represent.return_value = [
         {"embedding": [1.0], "face_confidence": 0.99, "facial_area": fa(w=120, h=170)}
     ]
 
     with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ") as mock_ofiq_cls:
-        encode_faces(encoding.deduplication_set, [encoding.id], make_encode_config())
+        encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], make_encode_config())
 
     mock_ofiq_cls.assert_not_called()
-    encoding.refresh_from_db()
-    assert encoding.embedding == [1.0]
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding == [1.0]
 
 
 @pytest.mark.django_db
-def test_encode_faces_ofiq_quality_passes_proceeds_to_deepface(mock_deepface, mock_storage, encoding_factory):
-    encoding = encoding_factory(filename="file.jpg", embedding=None)
+def test_encode_faces_ofiq_quality_passes_proceeds_to_deepface(mock_deepface, mock_storage, encoding_no_scores):
     mock_deepface.represent.return_value = [
         {"embedding": [1.0], "face_confidence": 0.99, "facial_area": fa(w=120, h=170)}
     ]
-    quality_pass = QualityCheckResult(passed=True, scores={"Sharpness": 80.0})
+    quality_pass = QualityCheckResult(passed=True, scores={"Sharpness": 0.8})
 
     with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ"):
         with patch("hope_dedup_engine.apps.faces.services.facial.check_image_quality", return_value=quality_pass):
-            encode_faces(encoding.deduplication_set, [encoding.id], make_config_with_ofiq())
+            encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], make_config_with_ofiq())
 
-    encoding.refresh_from_db()
-    assert encoding.embedding == [1.0]
-    assert encoding.embedding_status_code is None
-    assert encoding.image_quality_scores == {"Sharpness": 80.0}
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding == [1.0]
+    assert encoding_no_scores.embedding_status_code is None
+    assert encoding_no_scores.image_quality_scores == {"Sharpness": 0.8}
 
 
 @pytest.mark.django_db
-def test_encode_faces_ofiq_quality_fails_sets_bad_quality_status(mock_deepface, mock_storage, encoding_factory):
-    encoding = encoding_factory(filename="file.jpg", embedding=None)
-    quality_fail = QualityCheckResult(
-        passed=False,
-        face_detected=True,
-        scores={"Sharpness": 20.0},
-    )
+def test_encode_faces_ofiq_quality_fails_sets_bad_quality_status(mock_deepface, mock_storage, encoding_no_scores):
+    quality_fail = QualityCheckResult(passed=False, face_detected=True, scores={"Sharpness": 0.2})
 
     with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ"):
         with patch("hope_dedup_engine.apps.faces.services.facial.check_image_quality", return_value=quality_fail):
-            encode_faces(encoding.deduplication_set, [encoding.id], make_config_with_ofiq())
+            encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], make_config_with_ofiq())
 
     mock_deepface.represent.assert_not_called()
-    encoding.refresh_from_db()
-    assert encoding.embedding_status_code == Encoding.StatusCode.BAD_IMAGE_QUALITY
-    assert encoding.image_quality_scores == {"Sharpness": 20.0}
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding_status_code == Encoding.StatusCode.BAD_IMAGE_QUALITY
+    assert encoding_no_scores.image_quality_scores == {"Sharpness": 0.2}
 
 
 @pytest.mark.django_db
-def test_encode_faces_ofiq_no_face_detected_sets_no_face_status(mock_deepface, mock_storage, encoding_factory):
-    encoding = encoding_factory(filename="file.jpg", embedding=None)
+def test_encode_faces_ofiq_no_face_detected_sets_no_face_status(mock_deepface, mock_storage, encoding_no_scores):
     no_face = QualityCheckResult(passed=False, face_detected=False, scores={})
 
     with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ"):
         with patch("hope_dedup_engine.apps.faces.services.facial.check_image_quality", return_value=no_face):
-            encode_faces(encoding.deduplication_set, [encoding.id], make_config_with_ofiq())
+            encode_faces(encoding_no_scores.deduplication_set, [encoding_no_scores.id], make_config_with_ofiq())
 
     mock_deepface.represent.assert_not_called()
-    encoding.refresh_from_db()
-    assert encoding.embedding_status_code == Encoding.StatusCode.NO_FACE_DETECTED
+    encoding_no_scores.refresh_from_db()
+    assert encoding_no_scores.embedding_status_code == Encoding.StatusCode.NO_FACE_DETECTED
+    assert encoding_no_scores.image_quality_scores == {}
+
+
+@pytest.mark.django_db
+def test_encode_faces_reuses_cached_scores_skips_ofiq(mock_deepface, mock_storage, encoding_with_scores):
+    """Second encode with cached scores should not run OFIQ again."""
+    mock_deepface.represent.return_value = [
+        {"embedding": [1.0], "face_confidence": 0.99, "facial_area": fa(w=120, h=170)}
+    ]
+
+    with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ") as mock_ofiq_cls:
+        encode_faces(
+            encoding_with_scores.deduplication_set,
+            [encoding_with_scores.id],
+            make_config_with_ofiq(sharpness=50),
+        )
+
+    mock_ofiq_cls.return_value.vector_quality.assert_not_called()
+    encoding_with_scores.refresh_from_db()
+    assert encoding_with_scores.embedding == [1.0]
+    assert encoding_with_scores.image_quality_scores == {"Sharpness": 0.8}
+
+
+@pytest.mark.django_db
+def test_encode_faces_cached_scores_fail_new_thresholds(mock_deepface, mock_storage, encoding_with_scores):
+    """Cached scores that fail raised thresholds should set BAD_IMAGE_QUALITY without running OFIQ."""
+    with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ") as mock_ofiq_cls:
+        encode_faces(
+            encoding_with_scores.deduplication_set,
+            [encoding_with_scores.id],
+            make_config_with_ofiq(sharpness=90),
+        )
+
+    mock_ofiq_cls.return_value.vector_quality.assert_not_called()
+    mock_deepface.represent.assert_not_called()
+    encoding_with_scores.refresh_from_db()
+    assert encoding_with_scores.embedding_status_code == Encoding.StatusCode.BAD_IMAGE_QUALITY
+    assert encoding_with_scores.image_quality_scores == {"Sharpness": 0.8}
+
+
+@pytest.mark.django_db
+def test_encode_faces_cached_no_face_skips_ofiq(mock_deepface, mock_storage, encoding_empty_scores):
+    """Cached empty scores (no face) should skip OFIQ and DeepFace on re-encode."""
+    with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ") as mock_ofiq_cls:
+        encode_faces(encoding_empty_scores.deduplication_set, [encoding_empty_scores.id], make_config_with_ofiq())
+
+    mock_ofiq_cls.return_value.vector_quality.assert_not_called()
+    mock_deepface.represent.assert_not_called()
+    encoding_empty_scores.refresh_from_db()
+    assert encoding_empty_scores.embedding_status_code == Encoding.StatusCode.NO_FACE_DETECTED
+    assert encoding_empty_scores.image_quality_scores == {}
+
+
+@pytest.mark.django_db
+def test_encode_faces_cached_scores_skip_image_load_on_rejection(mock_deepface, mock_storage, encoding_with_scores):
+    """When cached scores fail thresholds, image should not be loaded."""
+    with patch("hope_dedup_engine.apps.faces.services.facial.OFIQ"):
+        encode_faces(
+            encoding_with_scores.deduplication_set,
+            [encoding_with_scores.id],
+            make_config_with_ofiq(sharpness=90),
+        )
+
+    mock_storage.assert_not_called()
+    mock_deepface.represent.assert_not_called()
 
 
 @pytest.mark.django_db

--- a/tests/apps/faces/services/test_quality.py
+++ b/tests/apps/faces/services/test_quality.py
@@ -6,6 +6,8 @@ import pytest
 from hope_dedup_engine.apps.api.deduplication.config import DeduplicationSetConfig
 from hope_dedup_engine.apps.faces.services.quality import (
     check_image_quality,
+    compute_ofiq_scores,
+    evaluate_quality_thresholds,
     get_active_thresholds,
 )
 
@@ -69,9 +71,82 @@ def mock_ofiq():
 
 
 @patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
+def test_compute_ofiq_scores_normalizes_to_0_1(mock_cvt, mock_ofiq, sample_bgr_image):
+    mock_cvt.return_value = sample_bgr_image
+    mock_ofiq.vector_quality.return_value = {"Sharpness": 80.0, "EyesOpen": 0.0}
+
+    scores, face_detected = compute_ofiq_scores(mock_ofiq, sample_bgr_image)
+
+    assert face_detected is True
+    assert scores == {"Sharpness": 0.8, "EyesOpen": 0.0}
+
+
+@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
+def test_compute_ofiq_scores_preserves_none_values(mock_cvt, mock_ofiq, sample_bgr_image):
+    mock_cvt.return_value = sample_bgr_image
+    mock_ofiq.vector_quality.return_value = {"Sharpness": 80.0, "EyesOpen": None}
+
+    scores, face_detected = compute_ofiq_scores(mock_ofiq, sample_bgr_image)
+
+    assert face_detected is True
+    assert scores == {"Sharpness": 0.8, "EyesOpen": None}
+
+
+@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
+def test_compute_ofiq_scores_no_face_returns_empty_dict(mock_cvt, mock_ofiq, sample_bgr_image):
+    from ofiq import FaceDetectionError
+
+    mock_cvt.return_value = sample_bgr_image
+    mock_ofiq.vector_quality.side_effect = FaceDetectionError()
+
+    scores, face_detected = compute_ofiq_scores(mock_ofiq, sample_bgr_image)
+
+    assert face_detected is False
+    assert scores == {}
+
+
+@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
+def test_compute_ofiq_scores_converts_bgr_to_rgb(mock_cvt, mock_ofiq, sample_bgr_image):
+    import cv2
+
+    mock_cvt.return_value = sample_bgr_image
+    mock_ofiq.vector_quality.return_value = {}
+
+    compute_ofiq_scores(mock_ofiq, sample_bgr_image)
+
+    mock_cvt.assert_called_once_with(sample_bgr_image, cv2.COLOR_BGR2RGB)
+
+
+@pytest.mark.parametrize(
+    ("scores", "thresholds", "expected"),
+    [
+        ({"Sharpness": 0.8}, {"Sharpness": 50}, True),
+        ({"Sharpness": 0.3}, {"Sharpness": 50}, False),
+        ({"Sharpness": 0.5}, {"Sharpness": 50}, True),
+        ({"Sharpness": 0.8, "EyesOpen": 0.9}, {"Sharpness": 50, "EyesOpen": 70}, True),
+        ({"Sharpness": 0.8, "EyesOpen": 0.5}, {"Sharpness": 50, "EyesOpen": 70}, False),
+        ({}, {"Sharpness": 50}, False),
+        ({"Sharpness": None}, {"Sharpness": 50}, False),
+        ({"Sharpness": 0.8}, {}, True),
+    ],
+    ids=[
+        "passes_threshold",
+        "below_threshold",
+        "exactly_at_threshold",
+        "all_pass_multiple",
+        "one_fails_multiple",
+        "missing_metric",
+        "none_score_value",
+        "empty_thresholds",
+    ],
+)
+def test_evaluate_quality_thresholds(scores, thresholds, expected):
+    assert evaluate_quality_thresholds(scores, thresholds) == expected
+
+
+@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
 def test_check_image_quality_passes(mock_cvt, mock_ofiq, sample_bgr_image):
-    mock_rgb = np.zeros((100, 100, 3), dtype=np.uint8)
-    mock_cvt.return_value = mock_rgb
+    mock_cvt.return_value = sample_bgr_image
     mock_ofiq.vector_quality.return_value = {"Sharpness": 80.0, "EyesOpen": 90.0}
 
     result = check_image_quality(mock_ofiq, sample_bgr_image, {"Sharpness": 50, "EyesOpen": 70})
@@ -93,16 +168,6 @@ def test_check_image_quality_fails_below_threshold(mock_cvt, mock_ofiq, sample_b
 
 
 @patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
-def test_check_image_quality_missing_metric(mock_cvt, mock_ofiq, sample_bgr_image):
-    mock_cvt.return_value = sample_bgr_image
-    mock_ofiq.vector_quality.return_value = {}
-
-    result = check_image_quality(mock_ofiq, sample_bgr_image, {"Sharpness": 50})
-
-    assert result.passed is False
-
-
-@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
 def test_check_image_quality_no_face_detected(mock_cvt, mock_ofiq, sample_bgr_image):
     from ofiq import FaceDetectionError
 
@@ -115,13 +180,19 @@ def test_check_image_quality_no_face_detected(mock_cvt, mock_ofiq, sample_bgr_im
     assert result.face_detected is False
 
 
-@patch("hope_dedup_engine.apps.faces.services.quality.cv2.cvtColor")
-def test_check_image_quality_converts_bgr_to_rgb(mock_cvt, mock_ofiq, sample_bgr_image):
-    import cv2
+def test_check_image_quality_reuses_cached_scores(mock_ofiq):
+    result = check_image_quality(mock_ofiq, None, {"Sharpness": 50}, cached_scores={"Sharpness": 0.8})
 
-    mock_cvt.return_value = sample_bgr_image
-    mock_ofiq.vector_quality.return_value = {}
+    assert result.passed is True
+    assert result.face_detected is True
+    assert result.scores == {"Sharpness": 0.8}
+    mock_ofiq.vector_quality.assert_not_called()
 
-    check_image_quality(mock_ofiq, sample_bgr_image, {})
 
-    mock_cvt.assert_called_once_with(sample_bgr_image, cv2.COLOR_BGR2RGB)
+def test_check_image_quality_cached_empty_scores_means_no_face(mock_ofiq):
+    result = check_image_quality(mock_ofiq, None, {"Sharpness": 50}, cached_scores={})
+
+    assert result.passed is False
+    assert result.face_detected is False
+    assert result.scores == {}
+    mock_ofiq.vector_quality.assert_not_called()


### PR DESCRIPTION
[AB#318833](https://unicef.visualstudio.com/4e044e8d-bc28-4768-8074-f80ff6e4a0e5/_workitems/edit/318833)

Image quality scores from OFIQ are now computed once per encoding, persisted, and reused on subsequent encode/dedupe runs instead of being recalculated every time.

