### PR TITLE
feat: allow findings retrieval for approved sets

### DIFF
--- a/src/hope_dedup_engine/apps/api/views.py
+++ b/src/hope_dedup_engine/apps/api/views.py
@@ -369,7 +369,7 @@ class FindingsViewSet(
                 deduplication_set__pk=self.kwargs["deduplication_set_pk"],
                 deduplication_set__group__system=self.request.auth.system,
                 deduplication_set__group__deleted=False,
-                deduplication_set__state=DeduplicationSet.State.DEDUPLICATED,
+                deduplication_set__state__in=[DeduplicationSet.State.DEDUPLICATED, DeduplicationSet.State.APPROVED],
             )
             .select_related("first_encoding", "second_encoding")
             .order_by("-updated_at", "-id")

--- a/tests/api/test_duplicate_list.py
+++ b/tests/api/test_duplicate_list.py
@@ -15,8 +15,15 @@ UPDATED_BEFORE = "updated_before"
 
 
 @pytest.fixture
-def deduplicated_set(deduplication_set: DeduplicationSet) -> DeduplicationSet:
-    deduplication_set.state = DeduplicationSet.State.DEDUPLICATED
+def deduplicated_set(
+    request: pytest.FixtureRequest,
+    deduplication_set: DeduplicationSet,
+) -> DeduplicationSet:
+    deduplication_set.state = getattr(
+        request,
+        "param",
+        DeduplicationSet.State.DEDUPLICATED,
+    )
     deduplication_set.save(update_fields=["state"])
     return deduplication_set
 
@@ -25,6 +32,14 @@ def findings_url(deduplication_set_pk: str) -> str:
     return reverse(FINDINGS_VIEW, kwargs={"deduplication_set_pk": deduplication_set_pk})
 
 
+@pytest.mark.parametrize(
+    "deduplicated_set",
+    [
+        DeduplicationSet.State.DEDUPLICATED,
+        DeduplicationSet.State.APPROVED,
+    ],
+    indirect=True,
+)
 def test_can_list_duplicates(api_client: APIClient, deduplicated_set: DeduplicationSet, finding: Finding) -> None:
     response = api_client.get(findings_url(deduplicated_set.pk))
     assert response.status_code == status.HTTP_200_OK
@@ -33,7 +48,7 @@ def test_can_list_duplicates(api_client: APIClient, deduplicated_set: Deduplicat
     assert "config" in data["results"][0]
 
 
-def test_findings_only_visible_when_deduplicated(
+def test_findings_only_visible_when_deduplicated_or_approved(
     api_client: APIClient, deduplication_set: DeduplicationSet, finding: Finding
 ) -> None:
     response = api_client.get(findings_url(deduplication_set.pk))


### PR DESCRIPTION
- Allow the findings endpoint to return findings for both deduplicated and approved sets.

This keeps findings available after a deduplication set is approved.
